### PR TITLE
use lodash.reduce to prevent packaging all of lodash in our package

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "d3-force": "^1.0.2",
     "global": "^4.3.0",
-    "lodash": "^4.17.4",
+    "lodash.reduce": "^4.6.0",
     "react-addons-shallow-compare": "0.14.x - 15.x"
   },
   "scripts": {

--- a/src/components/ForceGraph.js
+++ b/src/components/ForceGraph.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React, { PropTypes, Children, cloneElement } from 'react';
-import { reduce } from 'lodash';
+import reduce from 'lodash.reduce';
 
 import './ForceGraph.css';
 import PureRenderComponent from './PureRenderComponent';


### PR DESCRIPTION
before:
<img width="974" alt="screen shot 2017-06-02 at 11 45 49 am" src="https://cloud.githubusercontent.com/assets/231133/26733569/3759a01a-4789-11e7-96c2-d881c796d9a5.png">


after:
<img width="949" alt="screen shot 2017-06-02 at 11 46 15 am" src="https://cloud.githubusercontent.com/assets/231133/26733559/305be444-4789-11e7-9529-4e6298bbaa6f.png">