### PR TITLE
fixed pass through of unknown props

### DIFF
--- a/src/components/ForceGraphArrowLink.js
+++ b/src/components/ForceGraphArrowLink.js
@@ -68,7 +68,7 @@ export default class ForceGraphArrowLink extends PureComponent {
           </marker>
         </defs>
 
-        <ForceGraphLink {...this.props} edgeOffset={targetRadius} markerEnd={`url(#${id})`} />
+        <ForceGraphLink {...spreadable} link={link} edgeOffset={targetRadius} markerEnd={`url(#${id})`} />
       </g>
     );
   }


### PR DESCRIPTION
Currenty the usage of `ForceGraphArrowLink` will pass through `targetRadius` to `ForceGraphLink` which is an unknown prop and will trigger react warnings in a dev environment.

This commit will swallow `targetRadius` in `ForceGraphArrowLink` and will pass through the rest. Fxes #43